### PR TITLE
fix(downloads): migrate lidarr onto shared downloads-postgres cluster

### DIFF
--- a/kubernetes/apps/downloads/lidarr/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/externalsecret.yaml
@@ -17,6 +17,28 @@ spec:
       engineVersion: v2
       data:
         LIDARR__AUTH__APIKEY: "{{ .lidarr_api_key }}"
+        LIDARR__POSTGRES__HOST: downloads-postgres-pooler.downloads.svc.cluster.local
+        LIDARR__POSTGRES__PORT: "5432"
+        LIDARR__POSTGRES__MAINDB: lidarr
+        LIDARR__POSTGRES__USER: lidarr
+        LIDARR__POSTGRES__PASSWORD: "{{ .DB_PASSWORD }}"
+        # --
+        INIT_POSTGRES_DBNAME: lidarr
+        INIT_POSTGRES_HOST: downloads-postgres-pooler.downloads.svc.cluster.local
+        INIT_POSTGRES_PASS: "{{ .DB_PASSWORD }}"
+        INIT_POSTGRES_USER: lidarr
+
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: password32
+      rewrite:
+        - regexp:
+            source: "password"
+            target: "DB_PASSWORD"
+
   data:
     - secretKey: lidarr_api_key
       remoteRef:

--- a/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/lidarr/app/helmrelease.yaml
@@ -29,6 +29,36 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
+        pod:
+          annotations:
+            k8s.ksgate.org/downloads-postgres-ready: |
+              {
+                "apiVersion": "postgresql.cnpg.io/v1",
+                "kind": "Cluster",
+                "name": "downloads-postgres",
+                "namespace": "downloads",
+                "expression": "resource.status.readyInstances >= 1"
+              }
+          schedulingGates:
+            - name: k8s.ksgate.org/downloads-postgres-ready
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.4.0@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+
+            env:
+              INIT_POSTGRES_SUPER_PASS:
+                valueFrom:
+                  secretKeyRef:
+                    name: downloads-postgres-superuser
+                    key: password
+
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+
         containers:
           app:
             image:
@@ -44,28 +74,6 @@ spec:
               LIDARR__SERVER__PORT: &port 8686
               LIDARR__LOG_LEVEL: info
               LIDARR__APP__THEME: dark
-
-              LIDARR__POSTGRES__HOST: lidarr-postgres-rw.downloads.svc.cluster.local
-              LIDARR__POSTGRES__PORT:
-                valueFrom:
-                  secretKeyRef:
-                    name: lidarr-postgres-app
-                    key: port
-              LIDARR__POSTGRES__MAINDB:
-                valueFrom:
-                  secretKeyRef:
-                    name: lidarr-postgres-app
-                    key: dbname
-              LIDARR__POSTGRES__USER:
-                valueFrom:
-                  secretKeyRef:
-                    name: lidarr-postgres-app
-                    key: username
-              LIDARR__POSTGRES__PASSWORD:
-                valueFrom:
-                  secretKeyRef:
-                    name: lidarr-postgres-app
-                    key: password
 
             envFrom:
               - secretRef:

--- a/kubernetes/apps/downloads/lidarr/database/kustomization.yaml
+++ b/kubernetes/apps/downloads/lidarr/database/kustomization.yaml
@@ -1,6 +1,0 @@
----
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-components:
-  - ../../../../components/database/postgres

--- a/kubernetes/apps/downloads/lidarr/ks.yaml
+++ b/kubernetes/apps/downloads/lidarr/ks.yaml
@@ -3,43 +3,6 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app lidarr-postgres
-  namespace: flux-system
-spec:
-  targetNamespace: &namespace downloads
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
-    - name: cnpg-operator
-      namespace: flux-system
-    - name: democratic-csi
-      namespace: storage
-  path: ./kubernetes/apps/downloads/lidarr/database
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  wait: true
-  interval: 30m
-  retryInterval: 1m
-  timeout: 5m
-  postBuild:
-    substitute:
-      APP: lidarr
-      NAMESPACE: *namespace
-      POSTGRES_VERSION: "18.1"
-      POSTGRES_STORAGE_CLASS: truenas-iscsi
-      POSTGRES_BACKUP_SCHEDULE: "30 3 * * *"
-      POSTGRES_STORAGE_SIZE: "20Gi"
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
   name: &app lidarr
 spec:
   targetNamespace: &namespace downloads
@@ -51,7 +14,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: lidarr-postgres
+    - name: downloads-postgres
 
   interval: 1h
   path: ./kubernetes/apps/downloads/lidarr/app


### PR DESCRIPTION
lidarr's dedicated CNPG cluster was silently deleted at some point, leaving the pod stuck in CreateContainerConfigError and an orphaned Flux Kustomization/ScheduledBackup behind. Drop the dedicated cluster and wire lidarr onto the shared downloads-postgres cluster using the same postgres-init/ExternalSecret pattern as audiobookrequest, bookshelf, and rreading-glasses.