### PR TITLE
fix(kube-prometheus-stack): size Prometheus memory to fit its TSDB in page cache

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helm/values.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helm/values.yaml
@@ -135,7 +135,7 @@ prometheus:
     enableAdminAPI: true
     walCompression: true
 
-    retention: 30d
+    retention: 24h
     retentionSize: 90GB
 
     storageSpec:
@@ -150,9 +150,9 @@ prometheus:
     resources:
       requests:
         cpu: 100m
-        memory: 1Gi
+        memory: 6Gi
       limits:
-        memory: 4Gi
+        memory: 12Gi
 
     # Additional scrape configs for services that don't have ServiceMonitors
     additionalScrapeConfigs:
@@ -162,7 +162,7 @@ prometheus:
           username_file: /etc/prometheus/secrets/minio-metrics-auth/username
           password_file: /etc/prometheus/secrets/minio-metrics-auth/password
         static_configs:
-          - targets: ["primary-hl.storage.svc.cluster.local:9000"]
+          - targets: ["minio.storage.svc.cluster.local:9000"]
 
       - job_name: node-exporter
         static_configs:
@@ -170,21 +170,6 @@ prometheus:
               - 10.168.2.91:9100
               - 10.168.2.92:9100
               - 10.168.2.93:9100
-
-    remoteWrite:
-      - url: http://mimir-gateway.observability.svc.cluster.local/api/v1/push
-        writeRelabelConfigs:
-          - sourceLabels: [__name__]
-            regex: 'prometheus_.*|go_.*'
-            action: drop
-        queueConfig:
-          capacity: 10000
-          maxSamplesPerSend: 2000
-          batchSendDeadline: 5s
-          minShards: 1
-          maxShards: 10
-
-    retention: 24h
 
 kubeApiServer:
   enabled: true


### PR DESCRIPTION
## Problem

`NodeDiskIOSaturation` firing on `control-01` for 12+ hours against `sde`, the TrueNAS iSCSI LUN backing the Prometheus TSDB — ~230 MB/s sustained reads, near-zero writes, aqu-sq 13–52, ~130 ms read latency. `DiskPressure` was `False` throughout, so this was never a space problem.

## Root cause

The container memory limit, not the disk.

| | |
|---|---|
| `prometheus` limit | 4 GiB |
| RSS | 3.37 GiB |
| page cache left inside cgroup | **0.6 GiB** |
| total TSDB on disk | **4.57 GiB** (2.72 blocks + 1.49 WAL + 0.24 head) |
| `pgmajfault` | **~50/s**, 0 restarts in 38d |

Prometheus mmaps its chunk files. A cgroup that can cache only ~13% of its own dataset evicts the rest continuously, and every re-touch becomes a major fault against a *network* LUN. Zero restarts across 38 days confirms cache reclaim rather than OOM — which is precisely why this surfaced as disk I/O instead of crashes.

The visible damage was rule evaluation. `kube-apiserver-burnrate.rules` went from ~2 s to 124–711 s per pass on a 30 s interval (group `evaluationTime` 360 s, 12× overrun), driven entirely by the `burnrate1d`/`burnrate3d` windows that must walk every block. That overrun produced `PrometheusMissingRuleEvaluations`.

## Fix

Requests 1 → 6 GiB, limit 4 → 12 GiB, so RSS plus the entire TSDB stays resident. Node was at 64% requested, 69% after.

## Verified live before merging

Patched the running `Prometheus` CR and measured:

| metric | before | after |
|---|---|---|
| sde read throughput | 237 MB/s | ~0 MB/s |
| aqu-sq (alert fires >10) | 15.7 (peak 52) | **0.11** |
| majfaults/s | 50.8 | **0.004** |
| cgroup page cache | 0.69 GiB | 2.59 GiB |
| burnrate group eval | 139 s (peak 711 s) | **1.9 s** |

New working set is 4.89 GiB against the 12 GiB limit (41%), leaving room for series growth. `NodeDiskIOSaturation`, `PrometheusMissingRuleEvaluations` and `PrometheusRemoteWriteBehind` all stopped firing.

## Also in this file, found while tracing the above

- **`retention` was declared twice** under `prometheusSpec` — `30d` at line 138 and `24h` at line 187. YAML last-wins, so **`30d` was never in effect**. Collapsed to a single explicit `24h` to match running behaviour rather than silently 30×-ing the data volume as a side effect of deleting a duplicate key. Raising it is a deliberate capacity decision — and note `burnrate1d`/`burnrate3d` cannot be satisfied at 24h retention either way.
- **Removed the dead `remoteWrite`** to `mimir-gateway`. Mimir was deleted in 48ce53b2, so the endpoint has not resolved since; `highest_sent_timestamp` was `0` and the queue never drained. That was `PrometheusRemoteWriteBehind`.
- **Repointed the `minio` scrape job** from `primary-hl.storage.svc.cluster.local` to `minio.storage.svc.cluster.local`. `primary-hl` was the operator tenant headless service and no longer exists after the move to an external Deployment. That was the `TargetDown` for the minio job.

## Unrelated, but worth a look

`SmartDeviceCriticalWarning` + `SmartDeviceTestFailed` are firing for **`nvme0` on control-01** (Samsung MZAL8256HDJD). Different device from `sde`, so not part of this incident, but a control-plane NVMe reporting a failed SMART self-test deserves its own attention. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
