### PR TITLE
feat(fstrim): trim the Talos EPHEMERAL filesystem on every node

### DIFF
--- a/kubernetes/apps/system/fstrim/app/helmrelease.yaml
+++ b/kubernetes/apps/system/fstrim/app/helmrelease.yaml
@@ -1,0 +1,137 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app fstrim
+spec:
+  interval: 1h
+  maxHistory: 2
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+
+  values:
+    controllers:
+      fstrim:
+        # A DaemonSet rather than a CronJob on purpose. A CronJob schedules one
+        # Pod per firing, so it can only ever trim whichever node that Pod lands
+        # on. Getting per-node coverage out of a CronJob means either pinning a
+        # CronJob per node by name (which would write node hostnames into this
+        # repo) or leaning on completions + parallelism + hostname anti-affinity
+        # (which hangs whenever a node is unreachable, and needs the count
+        # updated by hand whenever the cluster grows). The schedule for a
+        # maintenance task is arbitrary, so coverage wins; resources/fstrim.sh
+        # does its own interval timing.
+        type: daemonset
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          # Every node needs this, control-plane included -- Talos leaves
+          # EPHEMERAL untrimmed everywhere. The nodes carry no taints today;
+          # these are here so the DaemonSet does not silently stop covering the
+          # control plane if that ever changes.
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+            - key: node-role.kubernetes.io/master
+              operator: Exists
+              effect: NoSchedule
+
+          securityContext:
+            # FITRIM requires CAP_SYS_ADMIN. A non-root user cannot hold it
+            # without ambient capabilities, so this runs as uid 0 with every
+            # other capability dropped rather than as a fully privileged pod.
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+            seccompProfile:
+              type: RuntimeDefault
+
+        containers:
+          app:
+            image:
+              repository: docker.io/library/alpine
+              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
+
+            # busybox provides /sbin/fstrim, including -v. Invoked via `sh` so
+            # the ConfigMap does not need an exec bit.
+            command:
+              - /bin/sh
+              - /etc/fstrim/fstrim.sh
+
+            # No TZ here on purpose. This Kustomization declares no postBuild, so
+            # "${TIMEZONE}" would reach the container unsubstituted -- and adding
+            # postBuild would mean escaping every $labels and $1 in
+            # prometheusRule.yaml. The script logs with `date -u` and schedules
+            # by duration, so it has no use for a local timezone.
+            env:
+              MOUNTPOINT: /host/var
+              # Every 6h, well short of the distro-conventional weekly. Two
+              # reasons. EPHEMERAL on a control-plane node takes ~120 GiB/day, so
+              # a long gap lets the controller's free-block view drift far from
+              # what the filesystem actually holds. And Prometheus retention is
+              # deliberately 24h here (raising it reintroduces the page-cache
+              # thrashing that saturated a control-plane disk), so the companion
+              # alert in prometheusRule.yaml has to detect a stall inside that
+              # window -- it looks back 18h, which is three cycles of margin at
+              # this interval. Lengthening this means lengthening that too.
+              INTERVAL_SECONDS: "21600"
+              JITTER_MAX_SECONDS: "900"
+              NODE_NAME:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - SYS_ADMIN
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+
+    persistence:
+      script:
+        type: configMap
+        name: fstrim-configmap
+        globalMounts:
+          - path: /etc/fstrim
+            readOnly: true
+
+      # The Talos EPHEMERAL filesystem. Mounted read-only: FITRIM checks that
+      # the superblock is writable, not the bind mount's MNT_READONLY flag, so a
+      # read-only mount is enough to trim while keeping etcd and the containerd
+      # state under /var out of this container's reach. If the first run logs
+      # EROFS, drop the `readOnly: true` below.
+      hostvar:
+        type: hostPath
+        hostPath: /var
+        hostPathType: Directory
+        globalMounts:
+          - path: /host/var
+            readOnly: true

--- a/kubernetes/apps/system/fstrim/app/kustomization.yaml
+++ b/kubernetes/apps/system/fstrim/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./prometheusRule.yaml
+configMapGenerator:
+  - name: fstrim-configmap
+    files:
+      - ./resources/fstrim.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    # Defensive, same as prometheusRule.yaml: this app's Kustomization declares
+    # no postBuild today. fstrim.sh is full of ${...} shell expansions, so if one
+    # is ever added, substitution would blank every one of them and leave a
+    # script that starts, trims nothing, and sleeps forever.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/system/fstrim/app/prometheusRule.yaml
+++ b/kubernetes/apps/system/fstrim/app/prometheusRule.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fstrim-rules
+  annotations:
+    # Defensive. This app's Kustomization declares no postBuild today, so no
+    # variable substitution runs over it. If one is ever added, envsubst would
+    # read the `$labels` in the annotations and the `$1` in label_replace as
+    # variables and blank them out, leaving a rule that still loads but can
+    # never match. This keeps that from happening silently.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+spec:
+  groups:
+    - name: fstrim.rules
+      rules:
+        # Catches the failure mode the DaemonSet's own health cannot: fstrim
+        # running on schedule but discarding nothing, because the FITRIM ioctl is
+        # rejected (EROFS from a read-only mount, EPERM from a missing
+        # CAP_SYS_ADMIN) or because it is pointed at the wrong path. In all of
+        # those cases the pod stays Running and logs quietly once a cycle, so
+        # KubeDaemonSetNotScheduled and KubeDaemonSetRolloutStuck -- which
+        # kube-prometheus-stack already ships -- stay silent.
+        #
+        # The right-hand side of the join is the system-disk selector. It reads
+        # the device backing /var out of node_filesystem_size_bytes
+        # (/dev/nvme0n1p4, /dev/sda4, ...) and rewrites it to the parent disk
+        # (nvme0n1, sda) that node_disk_* reports against, which is why no node
+        # hostname or device name is hardcoded here: each node's system disk is
+        # whichever one holds EPHEMERAL. Ceph OSD devices are excluded for free,
+        # since they carry no /var filesystem.
+        #
+        # endpoint="http-metrics" pins this to the ServiceMonitor-scraped
+        # node-exporter series. A second scrape source produces the same metrics
+        # labelled instance="<ip>:9100" and covers only part of the cluster;
+        # without this matcher every node alerts twice.
+        - alert: FstrimSystemDiskNotTrimmed
+          annotations:
+            summary: |
+              System disk {{ $labels.device }} on {{ $labels.instance }} has not
+              been trimmed in 18h. The drive controller is not being told which
+              blocks are free, so it loses its spare area and write
+              amplification climbs.
+            description: |
+              Check the fstrim DaemonSet on this node:
+                kubectl -n system logs -l app.kubernetes.io/name=fstrim --tail=20
+              A "trim FAILED" line reporting EROFS means the hostvar mount needs
+              `readOnly: true` removed in the fstrim HelmRelease.
+          expr: |
+            (
+              increase(node_disk_discarded_sectors_total{endpoint="http-metrics"}[18h]) == 0
+            )
+            and on (instance, device) (
+              label_replace(
+                node_filesystem_size_bytes{mountpoint="/var", fstype="xfs", endpoint="http-metrics"},
+                "device", "$1", "device", "/dev/(.*?)p?[0-9]+"
+              )
+            )
+          for: 30m
+          labels:
+            severity: warning

--- a/kubernetes/apps/system/fstrim/app/resources/fstrim.sh
+++ b/kubernetes/apps/system/fstrim/app/resources/fstrim.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Periodically hand freed blocks back to the SSD controller (FITRIM) for the
+# Talos EPHEMERAL filesystem.
+#
+# Talos mounts EPHEMERAL without the `discard` option and ships no fstrim timer,
+# so nothing ever tells the drive which blocks the filesystem has released. The
+# controller keeps treating every LBA it has ever written as live data, dynamic
+# over-provisioning collapses toward zero, and write amplification climbs --
+# which is how a control-plane system disk reached 160% of its rated endurance
+# while its filesystem was only 41% full.
+#
+# Runs as a DaemonSet, not a CronJob: a CronJob schedules one Pod per firing, so
+# it would only ever trim a single node. See helmrelease.yaml.
+set -eu
+
+MOUNTPOINT="${MOUNTPOINT:-/host/var}"
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-86400}"
+JITTER_MAX_SECONDS="${JITTER_MAX_SECONDS:-1800}"
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+if [ ! -d "${MOUNTPOINT}" ]; then
+  log "FATAL: ${MOUNTPOINT} is not present; refusing to start"
+  exit 1
+fi
+
+# Stagger the nodes. fstrim discards every free extent it finds, so letting a
+# whole cluster fire simultaneously queues a large burst of discards against
+# every drive at once -- harmless, but pointless when the schedule is arbitrary.
+jitter="$(awk -v max="${JITTER_MAX_SECONDS}" 'BEGIN { srand(); print int(rand() * max) }')"
+
+log "start node=${NODE_NAME:-unknown} mountpoint=${MOUNTPOINT} interval=${INTERVAL_SECONDS}s jitter=${jitter}s"
+sleep "${jitter}"
+
+while :; do
+  started="$(date +%s)"
+
+  # fstrim is expected to succeed against a read-only bind mount: FITRIM gates
+  # on the *superblock* being writable, not the mount's MNT_READONLY flag, and
+  # it does not take mnt_want_write(). If this ever returns EROFS, drop the
+  # `readOnly: true` from the hostvar globalMount in helmrelease.yaml.
+  if output="$(fstrim -v "${MOUNTPOINT}" 2>&1)"; then
+    log "trim ok in $(($(date +%s) - started))s: ${output}"
+  else
+    rc=$?
+    log "trim FAILED (exit ${rc}) in $(($(date +%s) - started))s: ${output}"
+  fi
+
+  log "sleeping ${INTERVAL_SECONDS}s"
+  sleep "${INTERVAL_SECONDS}"
+done

--- a/kubernetes/apps/system/fstrim/ks.yaml
+++ b/kubernetes/apps/system/fstrim/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname fstrim
+  namespace: &namespace system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/apps/system/fstrim/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/system/kustomization.yaml
+++ b/kubernetes/apps/system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: &namespace system
 resources:
+  - ./fstrim/ks.yaml
   - ./intel-device-plugins/ks.yaml
   - ./k8tz/ks.yaml
   - ./kopia/ks.yaml


### PR DESCRIPTION
Talos mounts EPHEMERAL without the `discard` option and ships no fstrim timer, so nothing ever tells a system disk which blocks the filesystem has released. node_disk_discarded_sectors_total reads 0 on every node and has never been anything else. The only devices being trimmed are the Ceph OSDs, via bdev_enable_discard in the Rook values.

The controllers therefore treat every LBA they have ever written as live data. One control-plane system disk reports 255 GB of 256 GB in use while its filesystem holds 97 GiB of 237 GiB, so dynamic over-provisioning is effectively zero and every write forces garbage collection. That drive is at 160% of rated endurance with SMART reporting "NVM subsystem reliability has been degraded", and its controller busy time is twice that of an identically loaded peer that has written only 9% less. The peer is at 96%.

This does not recover the worn drive, which needs replacing. It stops the mechanism from consuming the next one.

Implemented as a DaemonSet rather than a CronJob. A CronJob schedules one Pod per firing, so it can only ever trim whichever node that Pod lands on. Per-node coverage from a CronJob means either pinning one per node by hostname, or completions plus parallelism plus hostname anti-affinity, which hangs whenever a node is unreachable and needs its count edited by hand as the cluster changes. The schedule for a maintenance task is arbitrary, so coverage wins and the script keeps its own interval.

The pod runs as uid 0 holding only CAP_SYS_ADMIN, which FITRIM requires and which a non-root user cannot hold without ambient capabilities. Host /var is mounted read-only: FITRIM gates on the superblock being writable rather than on the mount's MNT_READONLY flag, so read-only is enough to trim while keeping etcd and containerd state out of the container's reach. If that is wrong the first run logs EROFS and the mount needs readOnly dropped, so it fails loudly rather than silently.

Also adds FstrimSystemDiskNotTrimmed, which covers the failure the DaemonSet's own health cannot: fstrim running on schedule but discarding nothing because the ioctl is rejected or the path is wrong. The pod stays Running throughout, so KubeDaemonSetNotScheduled and KubeDaemonSetRolloutStuck never notice. The rule derives each node's system disk from whichever device backs /var and rewrites the partition to its parent disk, so no hostname or device name is hardcoded and Ceph OSDs are excluded for free. It is scoped to endpoint="http-metrics" because two scrape sources emit node-exporter metrics under the same job name, and the alert would otherwise fire twice for every node.

The 6h trim interval, the rule's 18h lookback and the 24h Prometheus retention are coupled. Retention is deliberately short to keep the TSDB resident in page cache, the lookback has to fit inside it, and the interval has to divide the lookback with margin. Lengthening any one of the three means revisiting the other two.