### PR TITLE
fix(emqx): upgrade to 6.2.3 to unblock operator reconciliation

### DIFF
--- a/kubernetes/apps/messaging/emqx-operator/cluster/cluster.yaml
+++ b/kubernetes/apps/messaging/emqx-operator/cluster/cluster.yaml
@@ -5,7 +5,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: public.ecr.aws/emqx/emqx:5.8.9
+  image: docker.io/emqx/emqx:6.2.3
   config:
     data: |
       authentication {


### PR DESCRIPTION
emqx-operator 2.3.x supports only EMQX 5.9, 5.10 and 6.x, but the cluster was pinned to 5.8.9. The operator's updateStatus reconciler calls two APIs unconditionally that do not exist before 5.9 -- /api/v5/load_rebalance/global_status and the durable-storage replication status. Both return HTTP 404 on 5.8.9, and updateStatus treats a 404 as a hard error, so Reconcile aborts at step 5 of 20 on every pass.

That starves updatePodConditions, the step that patches the apps.emqx.io/on-serving pod condition. Core pods declare that condition as a readinessGate, so they never became Ready despite passing their container probes. All three EndpointSlice entries were ready=false, leaving the emqx-listeners LoadBalancer and the dashboard with no serving backends since 2026-05-29, when the operator moved to 2.3.1. Only emqx-headless kept working, because it sets publishNotReadyAddresses, which is why the Erlang cluster stayed healthy and the breakage went unnoticed.

The image also has to move off public.ecr.aws, which published no tag after 5.8.9; that dead mirror is why Renovate saw no upgrade for eight months. OSS continued on docker.io as 6.x. Rolling upgrades to 6.0 are supported from 5.8.0 up, the auth and authz config shape is unchanged, and the core nodes keep no persistent volumes, so there is nothing to migrate.

Note that the operator cannot apply this on its own: addCoreSet and syncCoreSets are also downstream of the failing step, so the core StatefulSet must be scaled to zero once by hand to let the reconciler past updateStatus and build the new set.